### PR TITLE
fix: add noindex to error pages and slides

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,7 @@ interface Props {
   image?: string
   imageAlt?: string
   type?: 'website' | 'article'
+  noindex?: boolean
 }
 
 const {
@@ -23,6 +24,7 @@ const {
   image = '/og/default.png',
   imageAlt = 'Fusion Party Victoria - Taking back what they stole.',
   type = 'website',
+  noindex = false,
 } = Astro.props
 
 // Sanity stega-encodes editable strings with invisible characters; strip them
@@ -42,6 +44,7 @@ const canonicalImage = new URL(image, Astro.site ?? Astro.url)
     <SEO
       title={title}
       description={description}
+      noindex={noindex}
       openGraph={{
         basic: {
           title,

--- a/src/pages/403.astro
+++ b/src/pages/403.astro
@@ -21,6 +21,7 @@ const randomMessage = forbiddenMessages[Math.floor(Math.random() * forbiddenMess
 <BaseLayout
   title="403 - Access Denied | Fusion Party Victoria"
   description="You don't have permission to access this page."
+  noindex={true}
 >
   <Header />
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -27,6 +27,7 @@ const chaosMessages = ['OOPS!', 'YOO-HOO!', 'UH OH!', 'WHOOPS!', 'YIKES!', 'BONK
 <BaseLayout
   title="404 - Page Not Found | Fusion Party Victoria"
   description="Oops! This page doesn't exist. Let's get you back on track."
+  noindex={true}
 >
   <Header />
 

--- a/src/pages/500.astro
+++ b/src/pages/500.astro
@@ -31,6 +31,7 @@ const randomMessage = errorMessages[Math.floor(Math.random() * errorMessages.len
 <BaseLayout
   title="500 - Server Error | Fusion Party Victoria"
   description="Oops! Something went wrong on our end."
+  noindex={true}
 >
   <Header />
 

--- a/src/pages/503.astro
+++ b/src/pages/503.astro
@@ -21,6 +21,7 @@ const randomMessage = maintenanceMessages[Math.floor(Math.random() * maintenance
 <BaseLayout
   title="503 - Maintenance | Fusion Party Victoria"
   description="We're currently performing maintenance. We'll be back soon!"
+  noindex={true}
 >
   <Header />
 

--- a/src/pages/slides.astro
+++ b/src/pages/slides.astro
@@ -7,6 +7,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
     <title>Reignite Democracy — Strategy Session // 21 February 2026</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
Add noindex prop to BaseLayout and set it on 403, 404, 500, 503 pages via astro-seo. Add robots noindex meta directly to slides.astro (standalone page without BaseLayout).